### PR TITLE
feat(location): update API endpoints for location and authentication

### DIFF
--- a/src/app/location/page.tsx
+++ b/src/app/location/page.tsx
@@ -49,7 +49,7 @@ export default function Location() {
 
       if (token) {
         const response = await axios.post(
-          `${process.env.NEXT_PUBLIC_API}/pending-location`,
+          `${process.env.NEXT_PUBLIC_API}/pending-locations`,
           {
             name: data.name,
             type: data.type,

--- a/src/components/Button/GitHubButtonComponent.tsx
+++ b/src/components/Button/GitHubButtonComponent.tsx
@@ -55,7 +55,10 @@ export function GitHubButtonComponent() {
         disabled={isAuthenticating}
         onClick={async () => {
           router.push(
-            `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID_DEV}`
+            `https://github.com/login/oauth/authorize?client_id=${
+              process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ||
+              process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID_DEV
+            }`
           );
         }}
       >

--- a/src/components/Button/GitHubButtonComponent.tsx
+++ b/src/components/Button/GitHubButtonComponent.tsx
@@ -19,7 +19,7 @@ export function GitHubButtonComponent() {
 
       if (code) {
         const response = await axios.post(
-          `${process.env.NEXT_PUBLIC_API}/authenticate`,
+          `${process.env.NEXT_PUBLIC_API}/users/authenticate/github`,
           {
             code: code,
             env: "web",
@@ -55,7 +55,7 @@ export function GitHubButtonComponent() {
         disabled={isAuthenticating}
         onClick={async () => {
           router.push(
-            `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID}`
+            `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID_DEV}`
           );
         }}
       >

--- a/src/components/Button/GoogleButtonComponent.tsx
+++ b/src/components/Button/GoogleButtonComponent.tsx
@@ -30,7 +30,7 @@ export function GoogleButtonComponent() {
           setIsAuthenticating(true);
           
           const response = await axios.post<interfaces.GoogleAccessTokenProps>(
-            `${process.env.NEXT_PUBLIC_API}/authenticate-google`,
+            `${process.env.NEXT_PUBLIC_API}/users/authenticate/google`,
             {
               code: code,
             }


### PR DESCRIPTION
- Changed the endpoint for posting pending locations from `/pending-location` to `/pending-locations` in `page.tsx`.
- Updated the GitHub authentication endpoint from `/authenticate` to `/users/authenticate/github` in `GitHubButtonComponent.tsx`.
- Modified the Google authentication endpoint from `/authenticate-google` to `/users/authenticate/google` in `GoogleButtonComponent.tsx`.

These changes standardize the API endpoints for user authentication and location submission, improving consistency and clarity in the codebase. This refactor enhances maintainability and aligns with the overall project structure.