### PR TITLE
feat: add storage service abstraction for location sharing

### DIFF
--- a/src/app/location/page.tsx
+++ b/src/app/location/page.tsx
@@ -51,6 +51,18 @@ export default function Location() {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      if (!["image/png", "image/jpeg", "image/jpg"].includes(file.type)) {
+        toast.error("Please upload a valid PNG or JPG image.");
+        e.target.value = "";
+        return;
+      }
+      
+      if (file.size > 10 * 1024 * 1024) {
+        toast.error("Image size should be less than 10MB.");
+        e.target.value = "";
+        return;
+      }
+
       setValue("image", file);
       const reader = new FileReader();
       reader.onloadend = () => {
@@ -69,7 +81,7 @@ export default function Location() {
     try {
       setIsLoading(true);
 
-      let image_url = null;
+      let image_url: string | null = null;
       if (data.image) {
         image_url = await storageService.uploadImage(data.image);
       }

--- a/src/app/location/page.tsx
+++ b/src/app/location/page.tsx
@@ -12,6 +12,7 @@ import * as interfaces from "@/interfaces/index";
 import { InputTelephoneIntlComponent } from "@/components/InputTelephoneIntl/InputTelephoneIntlComponent";
 import { MapPickerComponent } from "@/components/MapPicker/MapPickerComponent";
 import Image from "next/image";
+import { storageService } from "@/services/StorageService";
 
 export default function Location() {
   const imageRef = useRef<HTMLImageElement>(null);
@@ -68,6 +69,11 @@ export default function Location() {
     try {
       setIsLoading(true);
 
+      let image_url = null;
+      if (data.image) {
+        image_url = await storageService.uploadImage(data.image);
+      }
+
       const response = await api.post(`/pending-locations`, {
         name: data.name,
         type: data.type,
@@ -76,6 +82,7 @@ export default function Location() {
           ? formatPhoneNumber(data.telephone)
           : data.telephone,
         coords: data.coords,
+        ...(image_url ? { image_url } : {}),
       });
       if (response.status === 200)
         toast.success("Location successfully shared! Thank you for helping 🤗");
@@ -431,7 +438,6 @@ export default function Location() {
               </span>
               <input
                 id="image-upload"
-                disabled
                 type="file"
                 accept="image/*"
                 onChange={handleImageChange}

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -6,8 +6,10 @@ export class MockStorageService implements IStorageService {
   async uploadImage(file: File): Promise<string> {
     // Simulate network delay
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log(`Mocking upload for file: ${file.name}`);
-    return `https://mock-storage.url/${encodeURIComponent(file.name)}`;
+    
+    // Generate a random ID to prevent leaking local filenames and avoid collisions
+    const randomId = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
+    return `https://mock-storage.url/${randomId}`;
   }
 }
 

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -1,0 +1,16 @@
+export interface IStorageService {
+  uploadImage(file: File): Promise<string>;
+}
+
+export class MockStorageService implements IStorageService {
+  async uploadImage(file: File): Promise<string> {
+    // Simulate network delay
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    console.log(`Mocking upload for file: ${file.name}`);
+    return `https://mock-storage.url/${encodeURIComponent(file.name)}`;
+  }
+}
+
+// Export a singleton instance. 
+// When the real backend is ready, we can swap this out with AWS S3 implementation.
+export const storageService = new MockStorageService();


### PR DESCRIPTION
This pull request introduces image upload functionality for location submissions, allowing users to attach an image when sharing a new location. The implementation uses a mock storage service for image uploads, preparing the codebase for future integration with a real backend. The form input for image selection is also enabled.

New image upload feature:

* Added a `MockStorageService` class and `IStorageService` interface in `src/services/StorageService.ts` to handle image uploads, returning a mock URL for the uploaded image. Exported a singleton `storageService` instance for use throughout the app.
* Integrated the image upload process into the location submission flow in `src/app/location/page.tsx`, uploading the image before submitting the location data and including the resulting `image_url` in the API request if an image is provided. [[1]](diffhunk://#diff-487fc307cb7fa846096bc59de76e358f3b09e66fcd3c054d18a9c6343841a536R72-R76) [[2]](diffhunk://#diff-487fc307cb7fa846096bc59de76e358f3b09e66fcd3c054d18a9c6343841a536R85)
* Enabled the file input for image uploads by removing the `disabled` attribute from the image upload field in the location form.
* Imported the new `storageService` in `src/app/location/page.tsx` to support the upload functionality.